### PR TITLE
Potential security issue in src_c/mask.c: Unchecked return from initialization function

### DIFF
--- a/src_c/mask.c
+++ b/src_c/mask.c
@@ -708,6 +708,7 @@ set_from_threshold(SDL_Surface *surf, bitmask_t *bitmask, int threshold)
     Uint8 bpp = format->BytesPerPixel;
     Uint8 *pixel = NULL;
     Uint8 rgba[4];
+    rgba = 0;
     int x, y;
 
     for (y = 0; y < surf->h; ++y) {
@@ -843,7 +844,9 @@ bitmask_threshold(bitmask_t *m, SDL_Surface *surf, SDL_Surface *surf2,
     Uint32 the_color, the_color2, rmask, gmask, bmask, rmask2, gmask2, bmask2;
     Uint8 *pix;
     Uint8 r, g, b, a;
+    b = 0;
     Uint8 tr, tg, tb, ta;
+    tb = 0;
     int bpp1, bpp2;
 
     format = surf->format;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

3 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/mask.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/mask.c#L717
Code extract:

```cpp
        pixel = (Uint8 *)surf->pixels + y * surf->pitch;

        for (x = 0; x < surf->w; ++x, pixel += bpp) {
            SDL_GetRGBA(get_pixel_color(pixel, bpp), format, rgba, rgba + 1, <------ HERE
                        rgba + 2, rgba + 3);
            if (rgba[3] > threshold) {
```

---
**Instance 2**
File : `src_c/mask.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/mask.c#L884
Code extract:

```cpp
        bpp2 = 0;
    }

    SDL_GetRGBA(color, format, &r, &g, &b, &a); <------ HERE
    SDL_GetRGBA(threshold, format, &tr, &tg, &tb, &ta);

```

---
**Instance 3**
File : `src_c/mask.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/mask.c#L885
Code extract:

```cpp
    }

    SDL_GetRGBA(color, format, &r, &g, &b, &a);
    SDL_GetRGBA(threshold, format, &tr, &tg, &tb, &ta); <------ HERE

    for (y = 0; y < surf->h; y++) {
```

