### PR TITLE
Potential security issue in src_c/math.c: Unchecked return from initialization function

### DIFF
--- a/src_c/math.c
+++ b/src_c/math.c
@@ -1311,6 +1311,7 @@ vector_slerp(pgVector *self, PyObject *args)
     PyObject *other;
     pgVector *ret;
     double other_coords[VECTOR_MAX_SIZE];
+    other_coords = 0;
     double tmp, angle, t, length1, length2, f0, f1, f2;
 
     if (!PyArg_ParseTuple(args, "Od:slerp", &other, &t)) {


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/math.c` 
Function: `_scalar_product` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/math.c#L1335
Code extract:

```cpp
        PyErr_SetString(PyExc_ValueError, "can't use slerp with Zero-Vector");
        return NULL;
    }
    tmp = (_scalar_product(self->coords, other_coords, self->dim) / <------ HERE
           (length1 * length2));
    /* make sure tmp is in the range [-1:1] so acos won't return NaN */
```

