### PR TITLE
Potential security issue in src_c/freetype/ft_unicode.c: Unchecked return from initialization function

### DIFF
--- a/src_c/freetype/ft_unicode.c
+++ b/src_c/freetype/ft_unicode.c
@@ -116,6 +116,7 @@ _PGFT_EncodePyString(PyObject *obj, int ucs4)
          * of the object expanding each byte to 32 bits.
          */
         char *src;
+        src = (void*)0;
         Py_ssize_t i;
 
         Bytes_AsStringAndSize(obj, &src, &len);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/freetype/ft_unicode.c` 
Function: `PyBytes_AsStringAndSize` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/freetype/ft_unicode.c#L121
Code extract:

```cpp
        char *src;
        Py_ssize_t i;

        Bytes_AsStringAndSize(obj, &src, &len); <------ HERE
        utf32_buffer = (PGFT_String *)_PGFT_malloc(SIZEOF_PGFT_STRING(len));
        if (!utf32_buffer) {
```

