### PR TITLE
Potential security issue in src_c/mixer.c: Unchecked return from initialization function

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -710,6 +710,8 @@ static PyObject *
 snd_get_length(PyObject *self, PyObject *args)
 {
     Mix_Chunk *chunk = pgSound_AsChunk(self);
+    format = 0;
+    channels = 0;
     int freq, channels, mixerbytes, numsamples;
     Uint16 format;
     MIXER_INIT_CHECK();


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/mixer.c` 
Function: `Mix_QuerySpec` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/mixer.c#L714
Code extract:

```cpp
{
    Mix_Chunk *chunk = pgSound_AsChunk(self);
    int freq, channels, mixerbytes, numsamples;
    Uint16 format; <------ HERE
    MIXER_INIT_CHECK();

```

