### PR TITLE
Potential security issue in src_c/surface.c: Unchecked return from initialization function

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1500,6 +1500,7 @@ surf_get_colorkey(PyObject *self, PyObject *args)
 
     if (!surf)
         return RAISE(pgExc_SDLError, "display Surface quit");
+    b = 0;
 
 #if IS_SDLv1
     if (surf->flags & SDL_OPENGL)
@@ -1699,6 +1700,7 @@ surf_convert(PyObject *self, PyObject *args)
     Uint32 colorkey;
     Uint8 key_r, key_g, key_b, key_a = 255;
     int has_colorkey = SDL_FALSE;
+    key_b = 0;
 
 #endif /* IS_SDLv2 */
 
@@ -2963,6 +2965,7 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
     SDL_Surface *surf = pgSurface_AsSurface(self);
     SDL_PixelFormat *format = NULL;
     Uint8 *pixels = NULL;
+    b = 0;
     Uint8 *pixel;
     int x, y;
     int min_x, min_y, max_x, max_y;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> When an initialization function is used to initialize a local variable, but the returned status code is not checked, reading the variable may result in undefined behaviour.</span>
---

4 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/surface.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/surface.c#L1119
Code extract:

```cpp
    SDL_GetRGBA(col, surf->format, rgba, rgba + 1, rgba + 2, rgba + 3);
#else  /* IS_SDLv2 */
    if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
        SDL_GetRGBA(col, surf->format, rgba, rgba + 1, rgba + 2, rgba + 3); <------ HERE
    else {
        SDL_GetRGB(col, surf->format, rgba, rgba + 1, rgba + 2);
```

---
**Instance 2**
File : `src_c/surface.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/surface.c#L1520
Code extract:

```cpp
    }

    if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
        SDL_GetRGBA(mapped_color, surf->format, &r, &g, &b, &a); <------ HERE
    else
        SDL_GetRGB(mapped_color, surf->format, &r, &g, &b);
```

---
**Instance 3**
File : `src_c/surface.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/surface.c#L1724
Code extract:

```cpp
    if (SDL_GetColorKey(surf, &colorkey) == 0){
        has_colorkey = SDL_TRUE;
        if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
            SDL_GetRGBA(colorkey, surf->format, &key_r, &key_g, &key_b, &key_a); <------ HERE
        else
            SDL_GetRGB(colorkey, surf->format, &key_r, &key_g, &key_b);
```

---
**Instance 4**
File : `src_c/surface.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/0f3cde6bc1377f9ecb1365c78900c3ef852f926a/src_c/surface.c#L3024
Code extract:

```cpp
                    value = *(Uint16 *)pixel;
                    break;
                case 3:
                    value = pixel[BYTE0]; <------ HERE
                    value |= pixel[BYTE1] << 8;
                    value |= pixel[BYTE2] << 16;
```

