### PR TITLE
Potential security issue in src_c/freetype/ft_render.c: Unchecked return from initialization function

### DIFF
--- a/src_c/freetype/ft_render.c
+++ b/src_c/freetype/ft_render.c
@@ -692,6 +692,7 @@ _PGFT_Render_Array(FreeTypeInstance *ft, pgFontObject *fontobj,
                    int x, int y, SDL_Rect *r)
 {
     pg_buffer pg_view;
+    pg_view = {};
     Py_buffer *view_p = (Py_buffer *)&pg_view;
 
     unsigned width;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/freetype/ft_render.c` 
Function: `_PGFT_Render_Array` 
https://github.com/siva-msft/pygame/blob/86a220175f562b9c061a8625318b54102158c8c7/src_c/freetype/ft_render.c#L717
Code extract:

```cpp
        PyErr_Format(PyExc_ValueError,
                     "expecting a 2d target array: got %id array instead",
                     (int)view_p->ndim);
        pgBuffer_Release(&pg_view); <------ HERE
        return -1;
    }
```

