### PR TITLE
Potential security issue in src_c/surface.c: Unchecked return from initialization function

### DIFF
--- a/src_c/surface.c
+++ b/src_c/surface.c
@@ -1500,6 +1500,7 @@ surf_get_colorkey(PyObject *self, PyObject *args)
 
     if (!surf)
         return RAISE(pgExc_SDLError, "display Surface quit");
+        b = 0;
 
 #if IS_SDLv1
     if (surf->flags & SDL_OPENGL)
@@ -1699,6 +1700,7 @@ surf_convert(PyObject *self, PyObject *args)
     Uint32 colorkey;
     Uint8 key_r, key_g, key_b, key_a = 255;
     int has_colorkey = SDL_FALSE;
+    key_b = 0;
 
 #endif /* IS_SDLv2 */
 
@@ -2971,6 +2973,7 @@ surf_get_bounding_rect(PyObject *self, PyObject *args, PyObject *kwargs)
     Uint32 value;
     Uint8 r, g, b, a;
     int has_colorkey = 0;
+    b = 0;
 #if IS_SDLv2
     Uint32 colorkey;
 #endif /* IS_SDLv2 */


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

4 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/surface.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/surface.c#L1119
Code extract:

```cpp
    SDL_GetRGBA(col, surf->format, rgba, rgba + 1, rgba + 2, rgba + 3);
#else  /* IS_SDLv2 */
    if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
        SDL_GetRGBA(col, surf->format, rgba, rgba + 1, rgba + 2, rgba + 3); <------ HERE
    else {
        SDL_GetRGB(col, surf->format, rgba, rgba + 1, rgba + 2);
```

---
**Instance 2**
File : `src_c/surface.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/surface.c#L1520
Code extract:

```cpp
    }

    if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
        SDL_GetRGBA(mapped_color, surf->format, &r, &g, &b, &a); <------ HERE
    else
        SDL_GetRGB(mapped_color, surf->format, &r, &g, &b);
```

---
**Instance 3**
File : `src_c/surface.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/surface.c#L1724
Code extract:

```cpp
    if (SDL_GetColorKey(surf, &colorkey) == 0){
        has_colorkey = SDL_TRUE;
        if (SDL_ISPIXELFORMAT_ALPHA(surf->format->format))
            SDL_GetRGBA(colorkey, surf->format, &key_r, &key_g, &key_b, &key_a); <------ HERE
        else
            SDL_GetRGB(colorkey, surf->format, &key_r, &key_g, &key_b);
```

---
**Instance 4**
File : `src_c/surface.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/surface.c#L3032
Code extract:

```cpp
                    assert(format->BytesPerPixel == 4);
                    value = *(Uint32 *)pixel;
            }
            SDL_GetRGBA(value, surf->format, &r, &g, &b, &a); <------ HERE
            if ((a >= min_alpha && has_colorkey == 0) ||
                (has_colorkey != 0 && (r != keyr || g != keyg || b != keyb))) {
```

