### PR TITLE
Potential security issue in src_c/image.c: Unchecked return from initialization function

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -847,8 +847,10 @@ image_fromstring(PyObject *self, PyObject *arg)
     PyObject *string;
     char *format, *data;
     SDL_Surface *surf = NULL;
+    data = (void*)0;
     int w, h, flipped = 0;
     Py_ssize_t len;
+    len = 0;
     int loopw, looph;
 
     if (!PyArg_ParseTuple(arg, "O!(ii)s|i", &Bytes_Type, &string, &w, &h,
@@ -1186,6 +1188,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     unsigned surf_alpha;
 #else  /* IS_SDLv2 */
     Uint8 surf_alpha;
+    surf_alpha = 0;
     int have_surf_colorkey = 0;
     Uint32 surf_colorkey;
 #endif /* IS_SDLv2 */


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

2 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/image.c` 
Function: `PyBytes_AsStringAndSize` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/image.c#L861
Code extract:

```cpp
    if (w < 1 || h < 1)
        return RAISE(PyExc_ValueError, "Resolution must be positive values");

    Bytes_AsStringAndSize(string, &data, &len); <------ HERE

    if (!strcmp(format, "P")) {
```

---
**Instance 2**
File : `src_c/image.c` 
Function: `SDL_GetSurfaceAlphaMod` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/image.c#L1207
Code extract:

```cpp
    }

#if IS_SDLv2
    SDL_GetSurfaceAlphaMod(surface, &surf_alpha); <------ HERE
    have_surf_colorkey = (SDL_GetColorKey(surface, &surf_colorkey) == 0);
#endif /* IS_SDLv2 */
```

