### PR TITLE
Potential security issue in src_c/surface_fill.c: Unchecked return from initialization function

### DIFF
--- a/src_c/surface_fill.c
+++ b/src_c/surface_fill.c
@@ -556,6 +556,7 @@ surface_fill_blend_rgba_add(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
+    cA = 0;
     Uint32 pixel;
     Uint32 tmp;
     int result = -1;
@@ -633,6 +634,7 @@ surface_fill_blend_rgba_sub(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
+    cA = 0;
     Uint32 pixel;
     Sint32 tmp2;
     int result = -1;
@@ -711,6 +713,7 @@ surface_fill_blend_rgba_mult(SDL_Surface *surface, SDL_Rect *rect,
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
+    cA = 0;
     Uint32 pixel;
     int result = -1;
 #if IS_SDLv1
@@ -787,6 +790,7 @@ surface_fill_blend_rgba_min(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
+    cA = 0;
     Uint32 pixel;
     int result = -1;
 #if IS_SDLv1
@@ -863,6 +867,7 @@ surface_fill_blend_rgba_max(SDL_Surface *surface, SDL_Rect *rect, Uint32 color)
     int n;
     SDL_PixelFormat *fmt = surface->format;
     Uint8 sR, sG, sB, sA, cR, cG, cB, cA;
+    cA = 0;
     Uint32 pixel;
     int result = -1;
 #if IS_SDLv1


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

15 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L98
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 2**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L192
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 3**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L285
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 4**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L378
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 5**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L471
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 6**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L567
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 7**
File : `src_c/surface_fill.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L585
Code extract:

```cpp

    switch (bpp) {
        case 1: {
            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA); <------ HERE
            while (height--) {
                LOOP_UNROLLED4(
```

---
**Instance 8**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L644
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 9**
File : `src_c/surface_fill.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L662
Code extract:

```cpp

    switch (bpp) {
        case 1: {
            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA); <------ HERE
            while (height--) {
                LOOP_UNROLLED4(
```

---
**Instance 10**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L721
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 11**
File : `src_c/surface_fill.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L739
Code extract:

```cpp

    switch (bpp) {
        case 1: {
            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA); <------ HERE
            while (height--) {
                LOOP_UNROLLED4(
```

---
**Instance 12**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L797
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 13**
File : `src_c/surface_fill.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L815
Code extract:

```cpp

    switch (bpp) {
        case 1: {
            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA); <------ HERE
            while (height--) {
                LOOP_UNROLLED4(
```

---
**Instance 14**
File : `src_c/surface_fill.c` 
Function: `SDL_GetSurfaceBlendMode` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L873
Code extract:

```cpp
#else /* IS_SDLv2 */
    int ppa;
    SDL_BlendMode mode;
    SDL_GetSurfaceBlendMode(surface, &mode); <------ HERE
    ppa = (fmt->Amask && mode != SDL_BLENDMODE_NONE);
#endif /* IS_SDLv2 */
```

---
**Instance 15**
File : `src_c/surface_fill.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/surface_fill.c#L891
Code extract:

```cpp

    switch (bpp) {
        case 1: {
            SDL_GetRGBA(color, fmt, &cR, &cG, &cB, &cA); <------ HERE
            while (height--) {
                LOOP_UNROLLED4(
```

