### PR TITLE
Potential security issue in src_c/transform.c: Unchecked return from initialization function

### DIFF
--- a/src_c/transform.c
+++ b/src_c/transform.c
@@ -1999,6 +1999,7 @@ laplacian(SDL_Surface *surf, SDL_Surface *destsurf)
     int total[4];
 
     Uint8 c1r, c1g, c1b, c1a;
+    c1a = 0;
     // Uint32 c1r, c1g, c1b, c1a;
     Uint8 acolor[4];
 


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/transform.c` 
Function: `SDL_GetRGBA` 
https://github.com/siva-msft/pygame/blob/a841945181c1dff96956c2c8b697d24daa446ffb/src_c/transform.c#L2110
Code extract:

```cpp
            total[3] = 0;

            for (ii = 0; ii < 9; ii++) {
                SDL_GetRGBA(sample[ii], format, &c1r, &c1g, &c1b, &c1a); <------ HERE
                total[0] += c1r;
                total[1] += c1g;
```

