### PR TITLE
Potential security issue in src_c/mixer.c: Unchecked return from initialization function

### DIFF
--- a/src_c/mixer.c
+++ b/src_c/mixer.c
@@ -711,7 +711,9 @@ snd_get_length(PyObject *self, PyObject *args)
 {
     Mix_Chunk *chunk = pgSound_AsChunk(self);
     int freq, channels, mixerbytes, numsamples;
+    channels = 0;
     Uint16 format;
+    format = 0;
     MIXER_INIT_CHECK();
 
     Mix_QuerySpec(&freq, &format, &channels);


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

1 instance of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/mixer.c` 
Function: `Mix_QuerySpec` 
https://github.com/siva-msft/pygame/blob/24dc49f6c0f62521a4dc1a75e945a35efa0b1ca7/src_c/mixer.c#L717
Code extract:

```cpp
    Uint16 format;
    MIXER_INIT_CHECK();

    Mix_QuerySpec(&freq, &format, &channels); <------ HERE
    if (format == AUDIO_S8 || format == AUDIO_U8)
        mixerbytes = 1;
```

