### PR TITLE
Potential security issue in src_c/pixelcopy.c: Unchecked return from initialization function

### DIFF
--- a/src_c/pixelcopy.c
+++ b/src_c/pixelcopy.c
@@ -482,6 +482,7 @@ array_to_surface(PyObject *self, PyObject *arg)
 {
     PyObject *surfobj, *arrayobj;
     pg_buffer pg_view;
+    pg_view = {};
     Py_buffer *view_p = (Py_buffer *)&pg_view;
     char *array_data;
     SDL_Surface *surf;
@@ -776,6 +777,7 @@ surface_to_array(PyObject *self, PyObject *args, PyObject *kwds)
     PyObject *arrayobj;
     PyObject *surfobj;
     pg_buffer pg_view;
+    pg_view = {};
     Py_buffer *view_p = (Py_buffer *)&pg_view;
     _pc_view_kind_t view_kind = VIEWKIND_RGB;
     Uint8 opaque = 255;
@@ -857,6 +859,7 @@ map_array(PyObject *self, PyObject *args)
     PyObject *format_surf;
     SDL_PixelFormat *format;
     pg_buffer src_pg_view;
+    src_pg_view = {};
     Py_buffer *src_view_p = 0;
     Uint8 *src;
     int src_ndim;
@@ -865,6 +868,7 @@ map_array(PyObject *self, PyObject *args)
     int src_green;
     int src_blue;
     pg_buffer tar_pg_view;
+    tar_pg_view = {};
     Py_buffer *tar_view_p = 0;
     Uint8 *tar;
     int ndim;
@@ -1140,6 +1144,7 @@ static PyObject *
 make_surface(PyObject *self, PyObject *arg)
 {
     pg_buffer pg_view;
+    pg_view = {};
     Py_buffer *view_p = (Py_buffer *)&pg_view;
     PyObject *surfobj;
     PyObject *args;


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

5 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/pixelcopy.c` 
Function: `array_to_surface` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/pixelcopy.c#L544
Code extract:

```cpp
    }

    if (sizex != surf->w || sizey != surf->h) {
        pgBuffer_Release(&pg_view); <------ HERE
        return RAISE(PyExc_ValueError, "array must match surface dimensions");
    }
```

---
**Instance 2**
File : `src_c/pixelcopy.c` 
Function: `surface_to_array` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/pixelcopy.c#L801
Code extract:

```cpp
        return 0;
    }
    if (_validate_view_format(view_p->format)) {
        pgBuffer_Release(&pg_view); <------ HERE
        pgSurface_Unlock(surfobj);
        return 0;
```

---
**Instance 3**
File : `src_c/pixelcopy.c` 
Function: `map_array` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/pixelcopy.c#L1121
Code extract:

```cpp

    /* Cleanup
     */
    pgBuffer_Release(&src_pg_view); <------ HERE
    pgBuffer_Release(&tar_pg_view);
    if (!pgSurface_Unlock(format_surf)) {
```

---
**Instance 4**
File : `src_c/pixelcopy.c` 
Function: `map_array` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/pixelcopy.c#L1122
Code extract:

```cpp
    /* Cleanup
     */
    pgBuffer_Release(&src_pg_view);
    pgBuffer_Release(&tar_pg_view); <------ HERE
    if (!pgSurface_Unlock(format_surf)) {
        return 0;
```

---
**Instance 5**
File : `src_c/pixelcopy.c` 
Function: `make_surface` 
https://github.com/siva-msft/pygame/blob/2a53e03c81ca1b8f2bbc573978a120a3a60b97d1/src_c/pixelcopy.c#L1156
Code extract:

```cpp
    }

    if (!(view_p->ndim == 2 || (view_p->ndim == 3 && view_p->shape[2] == 3))) {
        pgBuffer_Release(&pg_view); <------ HERE
        return RAISE(PyExc_ValueError, "must be a valid 2d or 3d array\n");
    }
```

