### PR TITLE
Potential security issue in src_c/image.c: Unchecked return from initialization function

### DIFF
--- a/src_c/image.c
+++ b/src_c/image.c
@@ -845,10 +845,10 @@ PyObject *
 image_fromstring(PyObject *self, PyObject *arg)
 {
     PyObject *string;
-    char *format, *data;
+    char *format, *data = (void*)0;
     SDL_Surface *surf = NULL;
     int w, h, flipped = 0;
-    Py_ssize_t len;
+    Py_ssize_t len = 0;
     int loopw, looph;
 
     if (!PyArg_ParseTuple(arg, "O!(ii)s|i", &Bytes_Type, &string, &w, &h,
@@ -1185,7 +1185,7 @@ SaveTGA_RW(SDL_Surface *surface, SDL_RWops *out, int rle)
     unsigned surf_flags;
     unsigned surf_alpha;
 #else  /* IS_SDLv2 */
-    Uint8 surf_alpha;
+    Uint8 surf_alpha = 0;
     int have_surf_colorkey = 0;
     Uint32 surf_colorkey;
 #endif /* IS_SDLv2 */


### PR DESCRIPTION
<span> What is a&nbsp;</span><span><b>Conditionally Uninitialized Variable? </b></span><span> The return value of a function that is potentially used to initialize a local variable is not checked. Therefore, reading the local variable may result in undefined behavior.</span>
---

2 instances of this defect were found in the following locations:
---
**Instance 1**
File : `src_c/image.c` 
Function: `PyBytes_AsStringAndSize` 
https://github.com/siva-msft/pygame/blob/24dc49f6c0f62521a4dc1a75e945a35efa0b1ca7/src_c/image.c#L861
Code extract:

```cpp
    if (w < 1 || h < 1)
        return RAISE(PyExc_ValueError, "Resolution must be positive values");

    Bytes_AsStringAndSize(string, &data, &len); <------ HERE

    if (!strcmp(format, "P")) {
```

---
**Instance 2**
File : `src_c/image.c` 
Function: `SDL_GetSurfaceAlphaMod` 
https://github.com/siva-msft/pygame/blob/24dc49f6c0f62521a4dc1a75e945a35efa0b1ca7/src_c/image.c#L1207
Code extract:

```cpp
    }

#if IS_SDLv2
    SDL_GetSurfaceAlphaMod(surface, &surf_alpha); <------ HERE
    have_surf_colorkey = (SDL_GetColorKey(surface, &surf_colorkey) == 0);
#endif /* IS_SDLv2 */
```

